### PR TITLE
refac: setup scripts now using `uv`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,6 @@ cython_debug/
 data/
 ckpts/
 noise_models/
+
+# uv virtual environments created by setup.sh
+.venvs/

--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,3 @@ cython_debug/
 data/
 ckpts/
 noise_models/
-
-# uv virtual environments created by setup.sh
-.venvs/

--- a/01_CARE/exercise.ipynb
+++ b/01_CARE/exercise.ipynb
@@ -55,7 +55,7 @@
    },
    "source": [
     "<div class=\"alert alert-danger\">\n",
-    "  Set your python kernel to <code>05_image_restoration</code>\n",
+    "  Set your python kernel to <code>05 Image Restoration (CARE/N2V)</code>\n",
     "</div>"
    ]
   },
@@ -951,7 +951,7 @@
     "2) Open a terminal and run:\n",
     "\n",
     "```bash\n",
-    "conda activate 05_image_restoration\n",
+    "source ~/.virtualenvs/05_image_restoration/bin/activate\n",
     "tensorboard --logdir 01_CARE/runs/\n",
     "```\n",
     "\n",

--- a/01_CARE/solution.ipynb
+++ b/01_CARE/solution.ipynb
@@ -55,7 +55,7 @@
    },
    "source": [
     "<div class=\"alert alert-danger\">\n",
-    "  Set your python kernel to <code>05_image_restoration</code>\n",
+    "  Set your python kernel to <code>05 Image Restoration (CARE/N2V)</code>\n",
     "</div>"
    ]
   },
@@ -989,7 +989,7 @@
     "2) Open a terminal and run:\n",
     "\n",
     "```bash\n",
-    "conda activate 05_image_restoration\n",
+    "source ~/.virtualenvs/05_image_restoration/bin/activate\n",
     "tensorboard --logdir 01_CARE/runs/\n",
     "```\n",
     "\n",

--- a/01_CARE/solution.py
+++ b/01_CARE/solution.py
@@ -37,7 +37,7 @@
 
 # %% [markdown] tags=[]
 # <div class="alert alert-danger">
-#   Set your python kernel to <code>05_image_restoration</code>
+#   Set your python kernel to <code>05 Image Restoration (CARE/N2V)</code>
 # </div>
 
 
@@ -808,7 +808,7 @@ optimizer = torch.optim.Adam(
 # 2) Open a terminal and run:
 #
 # ```bash
-# conda activate 05_image_restoration
+# source ~/.virtualenvs/05_image_restoration/bin/activate
 # tensorboard --logdir 01_CARE/runs/
 # ```
 #

--- a/02_Noise2Void/exercise.ipynb
+++ b/02_Noise2Void/exercise.ipynb
@@ -72,7 +72,7 @@
    },
    "source": [
     "<div class=\"alert alert-danger\">\n",
-    "Set your python kernel to <code>05_image_restoration</code>\n",
+    "Set your python kernel to <code>05 Image Restoration (CARE/N2V)</code>\n",
     "</div>"
    ]
   },

--- a/02_Noise2Void/exercise.ipynb
+++ b/02_Noise2Void/exercise.ipynb
@@ -424,7 +424,7 @@
     "\n",
     "Remember the configuration? Didn't we set `logger` to `tensorboard`? Then we can visualize the loss curve!\n",
     "\n",
-    "Open Tensorboard in the terminal (check Task 5 in 01_CARE) to monitor training. \n",
+    "Open Tensorboard in the terminal (check Task 6 in 01_CARE) to monitor training. \n",
     "Logs for this model are stored in the `02_Noise2Void/tb_logs/` folder.\n",
     "</div>\n",
     "\n",

--- a/02_Noise2Void/solution.ipynb
+++ b/02_Noise2Void/solution.ipynb
@@ -447,7 +447,7 @@
     "\n",
     "Remember the configuration? Didn't we set `logger` to `tensorboard`? Then we can visualize the loss curve!\n",
     "\n",
-    "Open Tensorboard in the terminal (check Task 5 in 01_CARE) to monitor training. \n",
+    "Open Tensorboard in the terminal (check Task 6 in 01_CARE) to monitor training. \n",
     "Logs for this model are stored in the `02_Noise2Void/tb_logs/` folder.\n",
     "</div>\n",
     "\n",

--- a/02_Noise2Void/solution.ipynb
+++ b/02_Noise2Void/solution.ipynb
@@ -72,7 +72,7 @@
    },
    "source": [
     "<div class=\"alert alert-danger\">\n",
-    "Set your python kernel to <code>05_image_restoration</code>\n",
+    "Set your python kernel to <code>05 Image Restoration (CARE/N2V)</code>\n",
     "</div>"
    ]
   },

--- a/02_Noise2Void/solution.py
+++ b/02_Noise2Void/solution.py
@@ -273,7 +273,7 @@ careamist.train(train_data=train_images_path, val_data=validation_images_path)
 #
 # Remember the configuration? Didn't we set `logger` to `tensorboard`? Then we can visualize the loss curve!
 #
-# Open Tensorboard in the terminal (check Task 5 in 01_CARE) to monitor training. 
+# Open Tensorboard in the terminal (check Task 6 in 01_CARE) to monitor training. 
 # Logs for this model are stored in the `02_Noise2Void/tb_logs/` folder.
 # </div>
 #

--- a/02_Noise2Void/solution.py
+++ b/02_Noise2Void/solution.py
@@ -54,7 +54,7 @@
 
 # %% [markdown] tags=[]
 # <div class="alert alert-danger">
-# Set your python kernel to <code>05_image_restoration</code>
+# Set your python kernel to <code>05 Image Restoration (CARE/N2V)</code>
 # </div>
 
 # %% tags=[]

--- a/03_MicroSplit/exercise.ipynb
+++ b/03_MicroSplit/exercise.ipynb
@@ -71,7 +71,7 @@
    },
    "source": [
     "<div class=\"alert alert-danger\">\n",
-    "Set your python kernel to <code>05_image_restoration_microsplit</code>\n",
+    "Set your python kernel to <code>05 Image Restoration (MicroSplit)</code>\n",
     "</div>"
    ]
   },
@@ -89,7 +89,7 @@
     "\n",
     "assert careamics.__version__ == \"0.0.12\", (\n",
     "    f\"Expected careamics version 0.0.12, but found {careamics.__version__}. \"\n",
-    "    \"Please make sure your kernel is set to `05_image_restoration_microsplit`.\"\n",
+    "    \"Please make sure your kernel is set to `05 Image Restoration (MicroSplit)`.\"\n",
     ")\n",
     "print(f\"careamics version {careamics.__version__} is correctly installed.\")"
    ]
@@ -662,7 +662,7 @@
     "In this case, you have to open a terminal and run:\n",
     "\n",
     "```\n",
-    "conda activate 05_image_restoration_microsplit\n",
+    "source ~/.virtualenvs/05_image_restoration_microsplit/bin/activate\n",
     "tensorboard --logdir 03_MicroSplit/tb_logs/\n",
     "```"
    ]

--- a/03_MicroSplit/solution.ipynb
+++ b/03_MicroSplit/solution.ipynb
@@ -71,7 +71,7 @@
    },
    "source": [
     "<div class=\"alert alert-danger\">\n",
-    "Set your python kernel to <code>05_image_restoration_microsplit</code>\n",
+    "Set your python kernel to <code>05 Image Restoration (MicroSplit)</code>\n",
     "</div>"
    ]
   },
@@ -89,7 +89,7 @@
     "\n",
     "assert careamics.__version__ == \"0.0.12\", (\n",
     "    f\"Expected careamics version 0.0.12, but found {careamics.__version__}. \"\n",
-    "    \"Please make sure your kernel is set to `05_image_restoration_microsplit`.\"\n",
+    "    \"Please make sure your kernel is set to `05 Image Restoration (MicroSplit)`.\"\n",
     ")\n",
     "print(f\"careamics version {careamics.__version__} is correctly installed.\")"
    ]
@@ -693,7 +693,7 @@
     "In this case, you have to open a terminal and run:\n",
     "\n",
     "```\n",
-    "conda activate 05_image_restoration_microsplit\n",
+    "source ~/.virtualenvs/05_image_restoration_microsplit/bin/activate\n",
     "tensorboard --logdir 03_MicroSplit/tb_logs/\n",
     "```"
    ]

--- a/03_MicroSplit/solution.py
+++ b/03_MicroSplit/solution.py
@@ -54,7 +54,7 @@
 
 # %% [markdown] tags=[]
 # <div class="alert alert-danger">
-# Set your python kernel to <code>05_image_restoration_microsplit</code>
+# Set your python kernel to <code>05 Image Restoration (MicroSplit)</code>
 # </div>
 
 # %% tags=[]
@@ -63,7 +63,7 @@ import careamics
 
 assert careamics.__version__ == "0.0.12", (
     f"Expected careamics version 0.0.12, but found {careamics.__version__}. "
-    "Please make sure your kernel is set to `05_image_restoration_microsplit`."
+    "Please make sure your kernel is set to `05 Image Restoration (MicroSplit)`."
 )
 print(f"careamics version {careamics.__version__} is correctly installed.")
 
@@ -427,7 +427,7 @@ trainer.fit(
 # In this case, you have to open a terminal and run:
 #
 # ```
-# conda activate 05_image_restoration_microsplit
+# source ~/.virtualenvs/05_image_restoration_microsplit/bin/activate
 # tensorboard --logdir 03_MicroSplit/tb_logs/
 # ```
 

--- a/04_bonus_COSDD/bonus-solution.py
+++ b/04_bonus_COSDD/bonus-solution.py
@@ -7,7 +7,7 @@
 
 # %% [markdown]
 # <div class="alert alert-danger">
-# Set your python kernel to <code>05_image_restoration_COSDD</code>
+# Set your python kernel to <code>05 Image Restoration (COSDD)</code>
 # </div>
 
 # %%

--- a/04_bonus_COSDD/exercise.ipynb
+++ b/04_bonus_COSDD/exercise.ipynb
@@ -45,7 +45,7 @@
    },
    "source": [
     "<div class=\"alert alert-danger\">\n",
-    "Set your python kernel to <code>05_image_restoration_COSDD</code>\n",
+    "Set your python kernel to <code>05 Image Restoration (COSDD)</code>\n",
     "</div>"
    ]
   },

--- a/04_bonus_COSDD/solution.ipynb
+++ b/04_bonus_COSDD/solution.ipynb
@@ -45,7 +45,7 @@
    },
    "source": [
     "<div class=\"alert alert-danger\">\n",
-    "Set your python kernel to <code>05_image_restoration_COSDD</code>\n",
+    "Set your python kernel to <code>05 Image Restoration (COSDD)</code>\n",
     "</div>"
    ]
   },

--- a/04_bonus_COSDD/solution.py
+++ b/04_bonus_COSDD/solution.py
@@ -20,7 +20,7 @@
 
 # %% [markdown] tags=[]
 # <div class="alert alert-danger">
-# Set your python kernel to <code>05_image_restoration_COSDD</code>
+# Set your python kernel to <code>05 Image Restoration (COSDD)</code>
 # </div>
 
 # %% tags=[]

--- a/cosdd_setup.sh
+++ b/cosdd_setup.sh
@@ -1,39 +1,45 @@
 #!/bin/bash
 
+# ----------------------------------------------------------------------
+# Ensure uv is installed
+# ----------------------------------------------------------------------
+if ! command -v uv &> /dev/null; then
+    echo "uv not found, installing..."
+    wget -qO- https://astral.sh/uv/install.sh | sh
+    # the installer drops uv in ~/.local/bin; make it available in this session
+    source "$HOME/.local/bin/env" 2>/dev/null || export PATH="$HOME/.local/bin:$PATH"
+else
+    echo "uv is already installed: $(uv --version)"
+fi
+
+# create environment for COSDD
 echo "======================================"
 echo "Creating environment for COSDD..."
 echo "======================================"
-ENV="05_image_restoration_COSDD"
-conda create -y -n "$ENV" python=3.11
-source "$(conda info --base)/etc/profile.d/conda.sh" # init conda
-conda activate "$ENV"
+ENV="$HOME/.virtualenvs/05_image_restoration_COSDD"
+uv venv --python 3.11 "$ENV"
+source "$ENV/bin/activate"
 
-# check that the environment was activated
-if [[ "$CONDA_DEFAULT_ENV" == "$ENV" ]]; then
-    echo "Environment activated successfully"
-else
-    echo "Failed to activate the environment"
-fi
+uv pip install torch torchvision
+uv pip install lightning ipykernel matplotlib tifffile scikit-learn scikit-image tensorboard ipywidgets
+python -m ipykernel install --user --name "05_image_restoration_COSDD" \
+    --display-name "05 Image Restoration (COSDD)"
 
-# Further instructions that should only run if the environment is active
-if [[ "$CONDA_DEFAULT_ENV" == "$ENV" ]]; then
-    pip install torch torchvision
-    pip install lightning ipykernel matplotlib tifffile scikit-learn scikit-image tensorboard ipywidgets
-
-    # Clone the COSDD repository
+# Clone the COSDD repository
+if [ ! -d "04_bonus_COSDD/COSDD" ]; then
     git clone https://github.com/krulllab/COSDD.git 04_bonus_COSDD/COSDD
-    cd 04_bonus_COSDD/COSDD
-    git checkout eae0b6c
+    git -C 04_bonus_COSDD/COSDD checkout eae0b6c
+else
+    echo "COSDD repository already exists, skipping clone."
 fi
+
+deactivate
 
 # other preparations
-cd 04_bonus_COSDD/
-if [ ! -d "checkpoints" ]; then
+if [ ! -d "04_bonus_COSDD/checkpoints" ]; then
     echo "Adding pretrained checkpoint..."
-    mkdir checkpoints
+    mkdir 04_bonus_COSDD/checkpoints
 fi
-cd checkpoints/
-if [ ! -d "mito-pretrained" ]; then
-    cp -r /mnt/efs/dl_jrc/data/05_image_restoration/COSDD/mito-pretrained .
+if [ ! -d "04_bonus_COSDD/checkpoints/mito-pretrained" ]; then
+    cp -r /mnt/efs/dl_jrc/data/05_image_restoration/COSDD/mito-pretrained 04_bonus_COSDD/checkpoints/
 fi
-cd ../../

--- a/setup.sh
+++ b/setup.sh
@@ -1,63 +1,52 @@
 #!/bin/bash
 
+# ----------------------------------------------------------------------
+# Ensure uv is installed
+# ----------------------------------------------------------------------
+if ! command -v uv &> /dev/null; then
+    echo "uv not found, installing..."
+    wget -qO- https://astral.sh/uv/install.sh | sh
+    # the installer drops uv in ~/.local/bin; make it available in this session
+    source "$HOME/.local/bin/env" 2>/dev/null || export PATH="$HOME/.local/bin:$PATH"
+else
+    echo "uv is already installed: $(uv --version)"
+fi
+
 # create environment for MicroSplit
 echo "======================================"
 echo "Creating environment for MicroSplit..."
 echo "======================================"
-ENV="05_image_restoration_microsplit"
-conda create -y -n "$ENV" python=3.11
-source "$(conda info --base)/etc/profile.d/conda.sh" # init conda
-conda activate "$ENV"
+ENV=".venvs/05_image_restoration_microsplit"
+uv venv --python 3.11 "$ENV"
+source "$ENV/bin/activate"
 
-# check that the environment was activated
-if [[ "$CONDA_DEFAULT_ENV" == "$ENV" ]]; then
-    echo "Environment activated successfully"
-else
-    echo "Failed to activate the environment"
-fi
+uv pip install \
+    "git+https://github.com/CAREamics/MicroSplit-reproducibility.git" \
+    tensorboard \
+    "setuptools<81" \
+    ipykernel
+python -m ipykernel install --user --name "05_image_restoration"
 
-# Further instructions that should only run if the environment is active
-if [[ "$CONDA_DEFAULT_ENV" == "$ENV" ]]; then
-    pip install git+https://github.com/CAREamics/MicroSplit-reproducibility.git
-    
-    # packages to run jupyter notebooks
-    pip install tensorboard
-    pip install "setuptools<81"  # setuptools>=81 removes pkg_resources, required by tensorboard<=2.20
-    pip install ipykernel
-    python -m ipykernel install --user --name "05_image_restoration"
-fi
-
+deactivate
 
 # create environment for CARE & N2V exercises
 echo "======================================================"
 echo "Creating environment for CARE, Noise2Void and COSDD..."
 echo "======================================================"
-ENV="05_image_restoration"
-conda create -y -n "$ENV" python=3.11
-source "$(conda info --base)/etc/profile.d/conda.sh" # init conda
-conda activate "$ENV"
+ENV=".venvs/05_image_restoration"
+uv venv --python 3.11 "$ENV"
+source "$ENV/bin/activate"
 
-# check that the environment was activated
-if [[ "$CONDA_DEFAULT_ENV" == "$ENV" ]]; then
-    echo "Environment activated successfully"
-else
-    echo "Failed to activate the environment"
-fi
+uv pip install \
+    careamics \
+    careamics_portfolio \
+    "git+https://github.com/dl-janelia/dlmbl-unet" \
+    tensorboard \
+    "setuptools<81" \
+    ipykernel
+python -m ipykernel install --user --name "05_image_restoration"
 
-# Further instructions that should only run if the environment is active
-if [[ "$CONDA_DEFAULT_ENV" == "$ENV" ]]; then
-    pip install careamics
-    pip install careamics_portfolio
-    pip install git+https://github.com/dl-janelia/dlmbl-unet
-    pip install tensorboard
-    pip install "setuptools<81"  # setuptools>=81 removes pkg_resources, required by tensorboard<=2.20
-
-    # packages to run jupyter notebooks
-    pip install ipykernel
-    python -m ipykernel install --user --name "05_image_restoration"
-fi
-
-# Download the data
+# Download the data (the 05_image_restoration env is still active)
 # CARE + N2V
 if [ ! -d "data/denoising-N2V_SEM.unzip" ] || [ ! -d "data/denoising-CARE_U2OS.unzip" ]; then
     echo "Downloading CARE + N2V data..."
@@ -65,3 +54,5 @@ if [ ! -d "data/denoising-N2V_SEM.unzip" ] || [ ! -d "data/denoising-CARE_U2OS.u
 else
     echo "CARE, N2V data already exists, skipping download."
 fi
+
+deactivate

--- a/setup.sh
+++ b/setup.sh
@@ -16,7 +16,7 @@ fi
 echo "======================================"
 echo "Creating environment for MicroSplit..."
 echo "======================================"
-ENV=".venvs/05_image_restoration_microsplit"
+ENV="$HOME/.virtualenvs/05_image_restoration_microsplit"
 uv venv --python 3.11 "$ENV"
 source "$ENV/bin/activate"
 
@@ -25,15 +25,16 @@ uv pip install \
     tensorboard \
     "setuptools<81" \
     ipykernel
-python -m ipykernel install --user --name "05_image_restoration"
+python -m ipykernel install --user --name "05_image_restoration_microsplit" \
+    --display-name "05 Image Restoration (MicroSplit)"
 
 deactivate
 
 # create environment for CARE & N2V exercises
 echo "======================================================"
-echo "Creating environment for CARE, Noise2Void and COSDD..."
+echo "Creating environment for CARE and Noise2Void..."
 echo "======================================================"
-ENV=".venvs/05_image_restoration"
+ENV="$HOME/.virtualenvs/05_image_restoration"
 uv venv --python 3.11 "$ENV"
 source "$ENV/bin/activate"
 
@@ -44,7 +45,8 @@ uv pip install \
     tensorboard \
     "setuptools<81" \
     ipykernel
-python -m ipykernel install --user --name "05_image_restoration"
+python -m ipykernel install --user --name "05_image_restoration" \
+    --display-name "05 Image Restoration (CARE/N2V)"
 
 # Download the data (the 05_image_restoration env is still active)
 # CARE + N2V


### PR DESCRIPTION
### Description

Previously, `setup.sh` was taking ages to install packages using conda + pip install. Now replaced with `uv`.
We install `uv` venvs into `~/.virtualenvs` so that they are automatically discoverable by VSCode.
For the same reason, we register kernels with `ipykernel`.
Updated all exercises to mirror these changes in the environment.
Everything tested and working smoothly ;)